### PR TITLE
Fixes compatibility with Python 3.9+, eliminates a serious memory leak

### DIFF
--- a/randomdict.py
+++ b/randomdict.py
@@ -36,9 +36,6 @@ class RandomDict(MutableMapping):
         self.keys[key] = i
     
     def __delitem__(self, key):
-        if not key in self.keys:
-            raise KeyError
-
         # index of item to delete is i
         i = self.keys[key]
         # last item in values array is
@@ -57,9 +54,6 @@ class RandomDict(MutableMapping):
         del self.keys[key]
     
     def __getitem__(self, key):
-        if not key in self.keys:
-            raise KeyError
-
         i = self.keys[key]
         return self.values[i][1]
 

--- a/randomdict.py
+++ b/randomdict.py
@@ -28,10 +28,10 @@ class RandomDict(MutableMapping):
     def __setitem__(self, key, val):
         if key in self.keys:
             i = self.keys[key]
-        else:
-            self.last_index += 1
-            i = self.last_index
-
+            self.values[i] = (key, val)
+            return
+        self.last_index += 1
+        i = self.last_index
         self.values.append((key, val))
         self.keys[key] = i
     

--- a/randomdict.py
+++ b/randomdict.py
@@ -1,15 +1,14 @@
 
 # From https://stackoverflow.com/a/70870131
 
-import sys 
-if sys.version_info[:2] >= (3, 8):
+try:
     from collections.abc import MutableMapping
-else:
+except ImportError:
     from collections import MutableMapping
 
 import random
 
-__version__ = '0.2.0'
+__version__ = '0.2.1'
 
 class RandomDict(MutableMapping):
     def __init__(self, *args, **kwargs):

--- a/randomdict.py
+++ b/randomdict.py
@@ -11,18 +11,12 @@ import random
 __version__ = '0.2.1'
 
 class RandomDict(MutableMapping):
-    def __init__(self, *args, **kwargs):
-        """ Create RandomDict object with contents specified by arguments.
-        Any argument
-        :param *args:       dictionaries whose contents get added to this dict
-        :param **kwargs:    key, value pairs will be added to this dict
-        """
-        # mapping of keys to array positions
+    def __init__(self, default_factory=None, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        self.default_factory = default_factory
         self.keys = {}
         self.values = []
         self.last_index = -1
-
-        self.update(*args, **kwargs)
 
     def __setitem__(self, key, val):
         if key in self.keys:
@@ -53,6 +47,10 @@ class RandomDict(MutableMapping):
         del self.keys[key]
     
     def __getitem__(self, key):
+        if key not in self.keys:
+            if self.default_factory is None:
+                raise KeyError(key)
+            self[key] = self.default_factory()
         i = self.keys[key]
         return self.values[i][1]
 

--- a/randomdict.py
+++ b/randomdict.py
@@ -1,5 +1,7 @@
 
-# From https://stackoverflow.com/a/70870131                                                                                                                          
+# From https://stackoverflow.com/a/70870131
+
+import sys 
 if sys.version_info[:2] >= (3, 8):
     from collections.abc import MutableMapping
 else:

--- a/randomdict.py
+++ b/randomdict.py
@@ -1,4 +1,10 @@
-from collections import MutableMapping
+
+# From https://stackoverflow.com/a/70870131                                                                                                                          
+if sys.version_info[:2] >= (3, 8):
+    from collections.abc import MutableMapping
+else:
+    from collections import MutableMapping
+
 import random
 
 __version__ = '0.2.0'


### PR DESCRIPTION
This PR lets the library work with recent versions of Python, and changes the algorithm to update existing keys in place, eliminating a serious memory leak (repeated updates to the same key led to unbounded growth). It also adds support so it can be used as a direct replacement for `defaultdict`. To ease use, provides a new method `replace_dicts()` that replaces all future dicts or `defaultdicts` with `RandomDict`.
